### PR TITLE
Force HTTPS for Notion cover URL

### DIFF
--- a/main.py
+++ b/main.py
@@ -359,7 +359,8 @@ def update_notion(book_data, page_id, isbn):
     page_count = book_data.get("pageCount", 0)
 
     update_data = {
-        "cover": {"external": {"url": banner}},
+        # Notion only accepts cover URLs over HTTPS
+        "cover": {"external": {"url": banner.replace("http://", "https://")}},
         "properties": {
             "Author": {"select": {"name": authors}},
             "Publisher": {"select": {"name": publisher}},


### PR DESCRIPTION
Notion only accepts cover URLs over HTTPS, and the google books API appears to only provide links using HTTP resulting in empty banners.

This change replaces "http://" with "https://" in Notion cover URLs so it will actually use them.